### PR TITLE
fix: change default HD path to `m/44'/1'/0'/0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Then, add accounts:
 ape trezor add <alias>
 ```
 
+The default [hierarchical deterministic derivation path](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) is `m/44'/1'/0'/0`, which is Trezor's default.
+
 Trezor accounts have the following capabilities in `ape`:
 
 1. Can sign transactions

--- a/ape_trezor/_cli.py
+++ b/ape_trezor/_cli.py
@@ -50,7 +50,7 @@ def _list(cli_ctx):
 @non_existing_alias_argument()
 @click.option(
     "--hd-path",
-    help="The Ethereum account derivation path prefix. Defaults to m/44'/60'/0'/0.",
+    help="The Ethereum account derivation path prefix. Defaults to m/44'/1'/0'/0.",
     callback=lambda ctx, param, arg: HDBasePath(arg),
 )
 def add(cli_ctx, alias, hd_path):

--- a/ape_trezor/hdpath.py
+++ b/ape_trezor/hdpath.py
@@ -23,7 +23,7 @@ class HDBasePath(HDPath):
     """
 
     def __init__(self, base_path=None):
-        base_path = base_path or "m/44'/60'/0'/0"
+        base_path = base_path or "m/44'/1'/0'/0"
         base_path = base_path.rstrip("/")
         super().__init__(base_path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def config():
 
 @pytest.fixture
 def key_file_data():
-    return {"address": "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B", "hdpath": "m/44'/60'/0'/0/0"}
+    return {"address": "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B", "hdpath": "m/44'/1'/0'/0/0"}
 
 
 @pytest.fixture

--- a/tests/test_choices.py
+++ b/tests/test_choices.py
@@ -17,4 +17,4 @@ def test_get_user_selected_account(mocker, mock_client, address):
     mock_prompt.side_effect = _side_effect
     selected_address, hdpath = choices.get_user_selected_account()
     assert selected_address == address
-    assert str(hdpath) == "m/44'/60'/0'/0/1"
+    assert str(hdpath) == "m/44'/1'/0'/0/1"


### PR DESCRIPTION
### What I did

fixes: #24

Trezor does not let us use the default Ethereum derivation path by default ([source](https://github.com/trezor/trezor-firmware/issues/1336#issuecomment-720126545)). 

### How to verify it

1. Plug in a Trezor
2. Check its Ethereum address in Trezor Suite
3. Add the Trezor account to ape:  `ape trezor add trezor`
4. Check that the address of index `0` is different from the address found in Trezor suite.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
