### PR TITLE
fix: issue preventing signing transactions from working

### DIFF
--- a/ape_trezor/_cli.py
+++ b/ape_trezor/_cli.py
@@ -50,7 +50,7 @@ def _list(cli_ctx):
 @non_existing_alias_argument()
 @click.option(
     "--hd-path",
-    help="The Ethereum account derivation path prefix. Defaults to m/44'/60'/0'/0.",
+    help="The Ethereum account derivation path prefix (defaults to m/44'/1'/0'/0).",
     callback=lambda ctx, param, arg: HDBasePath(arg),
 )
 def add(cli_ctx, alias, hd_path):

--- a/ape_trezor/_cli.py
+++ b/ape_trezor/_cli.py
@@ -50,7 +50,7 @@ def _list(cli_ctx):
 @non_existing_alias_argument()
 @click.option(
     "--hd-path",
-    help="The Ethereum account derivation path prefix (defaults to m/44'/1'/0'/0).",
+    help="The Ethereum account derivation path prefix (defaults to m/44'/60'/0'/0).",
     callback=lambda ctx, param, arg: HDBasePath(arg),
 )
 def add(cli_ctx, alias, hd_path):

--- a/ape_trezor/accounts.py
+++ b/ape_trezor/accounts.py
@@ -91,6 +91,9 @@ class TrezorAccount(AccountAPI):
         return MessageSignature(*signed_msg)  # type: ignore
 
     def sign_transaction(self, txn: TransactionAPI) -> Optional[TransactionSignature]:
-        signed_txn = self.client.sign_transaction(txn.dict())
+        txn_data = txn.dict()
+        if "data" in txn_data and not txn_data["data"]:
+            del txn_data["data"]
 
-        return TransactionSignature(*signed_txn)  # type: ignore
+        v, r, s = self.client.sign_transaction(txn_data)
+        return TransactionSignature(v=v, r=r, s=s)  # type: ignore

--- a/ape_trezor/client.py
+++ b/ape_trezor/client.py
@@ -43,6 +43,7 @@ class TrezorClient:
         try:
             message_type = get_address(self.client, address)
             return str(message_type)
+
         except PinException as err:
             raise InvalidPinError() from err
 

--- a/ape_trezor/client.py
+++ b/ape_trezor/client.py
@@ -39,9 +39,8 @@ class TrezorClient:
 
     def get_account_path(self, account_id: int) -> str:
         account_path = self._hd_root_path.get_account_path(account_id)
-        address = account_path.address
         try:
-            message_type = get_address(self.client, address)
+            message_type = get_address(self.client, account_path.address_n)
             return str(message_type)
 
         except PinException as err:
@@ -99,7 +98,7 @@ class TrezorAccountClient:
         to validate the message data.
         """
         ethereum_message_signature = sign_message(
-            self.client, self._account_hd_path.address, message
+            self.client, self._account_hd_path.address_n, message
         )
 
         return extract_signature_vrs_bytes(signature_bytes=ethereum_message_signature.signature)
@@ -123,7 +122,7 @@ class TrezorAccountClient:
         if tx_type == "0x00":  # Static transaction type
             tuple_reply = sign_tx(
                 self.client,
-                self._account_hd_path.address,
+                self._account_hd_path.address_n,
                 nonce=txn["nonce"],
                 gas_price=txn["maxFeePerGas"],
                 gas_limit=txn["gas"],
@@ -140,7 +139,7 @@ class TrezorAccountClient:
 
             tuple_reply = sign_tx_eip1559(
                 self.client,
-                self._account_hd_path.address,
+                self._account_hd_path.address_n,
                 nonce=txn["nonce"],
                 gas_limit=txn["gas"],
                 to=txn.get("receiver", ""),

--- a/ape_trezor/client.py
+++ b/ape_trezor/client.py
@@ -25,7 +25,7 @@ class TrezorClient:
     def __init__(self, hd_root_path: HDBasePath, client: LibTrezorClient = None):
         if not client:
             try:
-                self.client = get_default_client(path=str(hd_root_path))
+                self.client = get_default_client()
             except TransportException:
                 raise TrezorClientConnectionError()
             # Handles an unhandled usb exception in Trezor transport
@@ -74,7 +74,7 @@ class TrezorAccountClient:
         account_hd_path: HDPath,
     ):
         try:
-            self.client = get_default_client(path=str(account_hd_path))
+            self.client = get_default_client()
         except TransportException:
             raise TrezorClientConnectionError()
 

--- a/ape_trezor/client.py
+++ b/ape_trezor/client.py
@@ -127,7 +127,7 @@ class TrezorAccountClient(ManagerAccessMixin):
             if isinstance(tx_type, int):
                 tx_type = HexBytes(tx_type).hex()
             elif isinstance(tx_type, bytes):
-                tx_type = tx_type.hex()
+                tx_type = HexBytes(tx_type).hex()
 
         # NOTE: `trezorlib` expects empty bytes when no data.
         data = txn.get("data") or b""

--- a/ape_trezor/exceptions.py
+++ b/ape_trezor/exceptions.py
@@ -1,20 +1,38 @@
 from ape.exceptions import AccountsError
 
 
-class TrezorAccountException(AccountsError):
+class TrezorAccountError(AccountsError):
     """
     An error that occurs in the ape Trezor plugin.
     """
 
 
-class TrezorSigningError(TrezorAccountException):
+class InvalidPinError(TrezorAccountError):
+    """
+    An error raised when you enter the wrong PIN.
+    """
+
+    def __init__(self):
+        super().__init__("You have entered an invalid PIN.")
+
+
+class InvalidHDPathError(TrezorAccountError):
+    """
+    An error raised the given HD-Path is invalid.
+    """
+
+    def __init__(self, hd_path: str):
+        super().__init__(f"HD-Path '{hd_path}' is invalid.")
+
+
+class TrezorSigningError(TrezorAccountError):
     """
     An error that occurs when signing a message or transaction
     using the Trezor plugin.
     """
 
 
-class TrezorClientError(TrezorAccountException):
+class TrezorClientError(TrezorAccountError):
     def __init__(self, message: str, status: int = 0):
         self.status = status
         super().__init__(message)

--- a/ape_trezor/hdpath.py
+++ b/ape_trezor/hdpath.py
@@ -1,3 +1,7 @@
+from ape.utils import cached_property
+from trezorlib.tools import Address, parse_path  # type: ignore
+
+
 class HDPath:
     """
     A class representing an HD path. This class is the base class
@@ -14,6 +18,10 @@ class HDPath:
 
     def __str__(self):
         return self.path
+
+    @cached_property
+    def address(self) -> Address:
+        return parse_path(self.path)
 
 
 class HDBasePath(HDPath):

--- a/ape_trezor/hdpath.py
+++ b/ape_trezor/hdpath.py
@@ -20,7 +20,7 @@ class HDPath:
         return self.path
 
     @cached_property
-    def address(self) -> Address:
+    def address_n(self) -> Address:
         return parse_path(self.path)
 
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "eth-account",  # Use same version as eth-ape
         "eth-typing>=3.1",  # Influenced by eth-ape so no upper pin
         "click",  # Use same version as eth-ape
-        "trezor>=0.13.3,<0.14",
+        "trezor[ethereum]>=0.13.3,<0.14",
     ],
     entry_points={
         "ape_cli_subcommands": [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -61,5 +61,5 @@ class TestTrezorClient:
 def test_extract_signature_vrs_bytes(signature):
     v, r, s = extract_signature_vrs_bytes(signature)
     assert v == 27
-    assert r == HexBytes('0x8a183a2798a3513133a2f0a5dfdb3f8696034f783e0fb994d69a64a801b07409')
-    assert s == HexBytes('0x6cadc1eb65b05da34d7287c94454efadbcca2952476654f607b9a858847e49bc')
+    assert r == HexBytes("0x8a183a2798a3513133a2f0a5dfdb3f8696034f783e0fb994d69a64a801b07409")
+    assert s == HexBytes("0x6cadc1eb65b05da34d7287c94454efadbcca2952476654f607b9a858847e49bc")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,8 @@
+from ape_trezor.client import TrezorClient
+from ape_trezor.hdpath import HDPath
+
+
+def test_init_client_uses_hd_path(mocker):
+    factory_patch = mocker.patch("ape_trezor.client.get_default_client")
+    hd_path = HDPath("m/44'/60'/0'/0")
+    client = TrezorClient(hd_path)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,8 +1,49 @@
+import ape
+import pytest
+
 from ape_trezor.client import TrezorClient
-from ape_trezor.hdpath import HDPath
+from ape_trezor.hdpath import HDBasePath
 
 
-def test_init_client_uses_hd_path(mocker):
-    factory_patch = mocker.patch("ape_trezor.client.get_default_client")
-    hd_path = HDPath("m/44'/60'/0'/0")
-    client = TrezorClient(hd_path)
+@pytest.fixture
+def mock_device_client(mocker):
+    return mocker.MagicMock()
+
+
+@pytest.fixture
+def patch_create_default_client(mocker, mock_device_client):
+    patch = mocker.patch("ape_trezor.client.get_default_client")
+    patch.return_value = mock_device_client
+    return patch
+
+
+@pytest.fixture
+def hd_path():
+    return HDBasePath("m/44'/60'/0'/0")
+
+
+@pytest.fixture
+def client(hd_path, mock_device_client):
+    return TrezorClient(hd_path, client=mock_device_client)
+
+
+@pytest.fixture
+def mock_get_address(mocker):
+    return mocker.patch("ape_trezor.client.get_address")
+
+
+@pytest.fixture
+def address():
+    return ape.accounts.test_accounts[0].address
+
+
+class TestTrezorClient:
+    def test_init_creates_client(self, patch_create_default_client, hd_path, mock_device_client):
+        client = TrezorClient(hd_path)
+        assert patch_create_default_client.call_count == 1
+        assert client.client == mock_device_client
+
+    def test_get_account_path(self, client, mock_get_address, address):
+        mock_get_address.return_value = address
+        actual = client.get_account_path(1)
+        assert actual == address

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,8 +2,8 @@ import ape
 import pytest
 from hexbytes import HexBytes
 
-from ape_trezor.client import TrezorClient, extract_signature_vrs_bytes
-from ape_trezor.hdpath import HDBasePath
+from ape_trezor.client import TrezorAccountClient, TrezorClient, extract_signature_vrs_bytes
+from ape_trezor.hdpath import HDBasePath, HDPath
 
 
 @pytest.fixture
@@ -24,8 +24,8 @@ def hd_path():
 
 
 @pytest.fixture
-def client(hd_path, mock_device_client):
-    return TrezorClient(hd_path, client=mock_device_client)
+def account_hd_path():
+    return HDPath("m/44'/60'/0'/1")
 
 
 @pytest.fixture
@@ -46,7 +46,53 @@ def signature():
     )
 
 
+CHAIN_ID = 4
+TO_ADDRESS = "0xE3747e6341E0d3430e6Ea9e2346cdDCc2F8a4b5b"
+GAS_LIMIT = 21000
+NONCE = 6
+VALUE = 100000000000
+MAX_FEE_PER_GAS = 1500000008
+MAX_PRIORITY_FEE_PER_GAS = 1500000000
+GAS_PRICE = 1
+SIG_V = 27
+SIG_R = HexBytes("0x8a183a2798a3513133a2f0a5dfdb3f8696034f783e0fb994d69a64a801b07409")
+SIG_S = HexBytes("0x6cadc1eb65b05da34d7287c94454efadbcca2952476654f607b9a858847e49bc")
+
+
+@pytest.fixture
+def static_fee_transaction(address):
+    return {
+        "chainId": CHAIN_ID,
+        "to": TO_ADDRESS,
+        "from": address,
+        "gas": GAS_LIMIT,
+        "nonce": NONCE,
+        "value": VALUE,
+        "gasPrice": GAS_PRICE,
+    }
+
+
+@pytest.fixture
+def dynamic_fee_transaction(address):
+    return {
+        "chainId": CHAIN_ID,
+        "to": TO_ADDRESS,
+        "from": address,
+        "gas": GAS_LIMIT,
+        "nonce": NONCE,
+        "value": VALUE,
+        "type": "0x02",
+        "maxFeePerGas": MAX_FEE_PER_GAS,
+        "maxPriorityFeePerGas": MAX_PRIORITY_FEE_PER_GAS,
+        "accessList": [],
+    }
+
+
 class TestTrezorClient:
+    @pytest.fixture
+    def client(self, hd_path, mock_device_client):
+        return TrezorClient(hd_path, client=mock_device_client)
+
     def test_init_creates_client(self, patch_create_default_client, hd_path, mock_device_client):
         client = TrezorClient(hd_path)
         assert patch_create_default_client.call_count == 1
@@ -60,6 +106,62 @@ class TestTrezorClient:
 
 def test_extract_signature_vrs_bytes(signature):
     v, r, s = extract_signature_vrs_bytes(signature)
-    assert v == 27
-    assert r == HexBytes("0x8a183a2798a3513133a2f0a5dfdb3f8696034f783e0fb994d69a64a801b07409")
-    assert s == HexBytes("0x6cadc1eb65b05da34d7287c94454efadbcca2952476654f607b9a858847e49bc")
+    assert v == SIG_V
+    assert r == SIG_R
+    assert s == SIG_S
+
+
+class TestTrezorAccountClient:
+    @pytest.fixture
+    def account_client(self, address, account_hd_path, mock_device_client):
+        return TrezorAccountClient(address, account_hd_path, client=mock_device_client)
+
+    def test_sign_static_fee_transaction(
+        self,
+        mocker,
+        account_client,
+        static_fee_transaction,
+        mock_device_client,
+        account_hd_path,
+    ):
+        sign_eip1559_patch = mocker.patch("ape_trezor.client.sign_tx")
+        sign_eip1559_patch.return_value = (SIG_V, SIG_R, SIG_S)
+        actual = account_client.sign_transaction(static_fee_transaction)
+        assert actual == (SIG_V, SIG_R, SIG_S)
+        sign_eip1559_patch.assert_called_once_with(
+            mock_device_client,
+            account_hd_path.address_n,
+            nonce=NONCE,
+            gas_price=GAS_PRICE,
+            gas_limit=GAS_LIMIT,
+            to=TO_ADDRESS,
+            value=VALUE,
+            data=b"",
+            chain_id=CHAIN_ID,
+        )
+
+    def test_sign_dynamic_fee_transaction(
+        self,
+        mocker,
+        account_client,
+        dynamic_fee_transaction,
+        mock_device_client,
+        account_hd_path,
+    ):
+        sign_eip1559_patch = mocker.patch("ape_trezor.client.sign_tx_eip1559")
+        sign_eip1559_patch.return_value = (SIG_V, SIG_R, SIG_S)
+        actual = account_client.sign_transaction(dynamic_fee_transaction)
+        assert actual == (SIG_V, SIG_R, SIG_S)
+        sign_eip1559_patch.assert_called_once_with(
+            mock_device_client,
+            account_hd_path.address_n,
+            nonce=NONCE,
+            gas_limit=GAS_LIMIT,
+            to=TO_ADDRESS,
+            value=VALUE,
+            data=b"",
+            chain_id=CHAIN_ID,
+            max_gas_fee=MAX_FEE_PER_GAS,
+            max_priority_fee=MAX_PRIORITY_FEE_PER_GAS,
+            access_list=[],
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,8 @@
 import ape
 import pytest
+from hexbytes import HexBytes
 
-from ape_trezor.client import TrezorClient
+from ape_trezor.client import TrezorClient, extract_signature_vrs_bytes
 from ape_trezor.hdpath import HDBasePath
 
 
@@ -37,6 +38,14 @@ def address():
     return ape.accounts.test_accounts[0].address
 
 
+@pytest.fixture
+def signature():
+    return HexBytes(
+        "0x8a183a2798a3513133a2f0a5dfdb3f8696034f783e0fb994d69a64a801b07409"
+        "6cadc1eb65b05da34d7287c94454efadbcca2952476654f607b9a858847e49bc1b"
+    )
+
+
 class TestTrezorClient:
     def test_init_creates_client(self, patch_create_default_client, hd_path, mock_device_client):
         client = TrezorClient(hd_path)
@@ -47,3 +56,10 @@ class TestTrezorClient:
         mock_get_address.return_value = address
         actual = client.get_account_path(1)
         assert actual == address
+
+
+def test_extract_signature_vrs_bytes(signature):
+    v, r, s = extract_signature_vrs_bytes(signature)
+    assert v == 27
+    assert r == HexBytes('0x8a183a2798a3513133a2f0a5dfdb3f8696034f783e0fb994d69a64a801b07409')
+    assert s == HexBytes('0x6cadc1eb65b05da34d7287c94454efadbcca2952476654f607b9a858847e49bc')


### PR DESCRIPTION
### What I did

fixes: #26 

This fixes an issue when trying to transfer, it would fail saying it tried to deploy an empty contract. This is because the receiver key was wrong in the transaction dict.

There were some other issues with items from the txn dict so I fixed those as well, such as default expected types and such (copying from `trezorctl`).

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
