### PR TITLE
feat: support configuring hd path in `ape-config.yaml`

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -9,12 +9,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
               fetch-depth: 0
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: 3.8
 

--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -12,10 +12,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: 3.8
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,10 +7,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: 3.8
 
@@ -22,20 +22,20 @@ jobs:
         - name: Run Black
           run: black --check .
 
-        - name: Run flake8
-          run: flake8 .
-
         - name: Run isort
           run: isort --check-only .
+
+        - name: Run flake8
+          run: flake8 .
 
     type-check:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: 3.8
 
@@ -56,10 +56,10 @@ jobs:
                 python-version: [3.8, 3.9, "3.10"]
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: ${{ matrix.python-version }}
 
@@ -79,10 +79,10 @@ jobs:
 #            fail-fast: true
 #
 #        steps:
-#        - uses: actions/checkout@v2
+#        - uses: actions/checkout@v3
 #
 #        - name: Setup Python
-#          uses: actions/setup-python@v2
+#          uses: actions/setup-python@v4
 #          with:
 #              python-version: 3.8
 #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,21 +10,21 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.12.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.991
     hooks:
     -   id: mypy
-        additional_dependencies: [types-requests]
+        additional_dependencies: [types-setuptools, pydantic]
 
 
 default_language_version:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v0.991
     hooks:
     -   id: mypy
-        additional_dependencies: [types-setuptools, pydantic]
+        additional_dependencies: [types-PyYAML, types-setuptools, pydantic]
 
 
 default_language_version:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ ape trezor add <alias> --hd-path "m/44'/1'/0'/0"
  Changing the HD-Path in that circumstance will allow fewer warnings from both Ape and the device, as well as improved security.
  See https://github.com/trezor/trezor-firmware/issues/1336#issuecomment-720126545 for more information.
 
+```yaml
+trezor:
+  hd_path: "m/44'/1'/0'/0"
+```
+
 ## List Accounts
 
 To list just your Trezor accounts in `ape`, do:

--- a/ape_trezor/__init__.py
+++ b/ape_trezor/__init__.py
@@ -1,6 +1,11 @@
 from ape import plugins
 
-from .accounts import AccountContainer, TrezorAccount
+from .accounts import AccountContainer, TrezorAccount, TrezorConfig
+
+
+@plugins.register(plugins.Config)
+def config_class():
+    return TrezorConfig
 
 
 @plugins.register(plugins.AccountPlugin)

--- a/ape_trezor/client.py
+++ b/ape_trezor/client.py
@@ -1,14 +1,14 @@
-from typing import Callable, Tuple
+from typing import Callable, Optional, Tuple
 
 from ape.logging import logger
 from eth_typing.evm import ChecksumAddress
-from trezorlib.client import TrezorClient as LibTrezorClient  # type: ignore
-from trezorlib.client import get_default_client  # type: ignore
-from trezorlib.device import apply_settings  # type: ignore
-from trezorlib.ethereum import get_address, sign_message, sign_tx, sign_tx_eip1559  # type: ignore
-from trezorlib.exceptions import PinException, TrezorFailure  # type: ignore
-from trezorlib.messages import SafetyCheckLevel  # type: ignore
-from trezorlib.transport import TransportException  # type: ignore
+from trezorlib.client import TrezorClient as LibTrezorClient
+from trezorlib.client import get_default_client
+from trezorlib.device import apply_settings
+from trezorlib.ethereum import get_address, sign_message, sign_tx, sign_tx_eip1559
+from trezorlib.exceptions import PinException, TrezorFailure
+from trezorlib.messages import SafetyCheckLevel
+from trezorlib.transport import TransportException
 
 from ape_trezor.exceptions import (
     InvalidHDPathError,
@@ -30,7 +30,7 @@ class TrezorClient:
     This class is a client for the Trezor device.
     """
 
-    def __init__(self, hd_root_path: HDBasePath, client: LibTrezorClient = None):
+    def __init__(self, hd_root_path: HDBasePath, client: Optional[LibTrezorClient] = None):
         if not client:
             try:
                 self.client = get_default_client()
@@ -79,7 +79,10 @@ class TrezorAccountClient:
     """
 
     def __init__(
-        self, address: ChecksumAddress, account_hd_path: HDPath, client: LibTrezorClient = None
+        self,
+        address: ChecksumAddress,
+        account_hd_path: HDPath,
+        client: Optional[LibTrezorClient] = None,
     ):
         if not client:
             try:
@@ -163,6 +166,7 @@ class TrezorAccountClient:
 
 
 __all__ = [
+    "create_client",
     "TrezorClient",
     "TrezorAccountClient",
 ]

--- a/ape_trezor/hdpath.py
+++ b/ape_trezor/hdpath.py
@@ -1,5 +1,5 @@
 from ape.utils import cached_property
-from trezorlib.tools import Address, parse_path  # type: ignore
+from trezorlib.tools import Address, parse_path
 
 
 class HDPath:
@@ -18,6 +18,9 @@ class HDPath:
 
     def __str__(self):
         return self.path
+
+    def __repr__(self):
+        return f"<{self}>"
 
     @cached_property
     def address_n(self) -> Address:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
 [tool.mypy]
 exclude = "build/"
+plugins = ["pydantic.mypy"]
 
 [tool.setuptools_scm]
 write_to = "ape_trezor/version.py"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_packages, setup
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
@@ -12,10 +12,11 @@ extras_require = {
         "eip712",  # Used for cleaner test cases
     ],
     "lint": [
-        "black>=22.6.0,<23.0",  # auto-formatter and linter
-        "mypy==0.982",  # Static type analyzer
-        "flake8>=4.0.1,<5.0",  # Style linter
-        "isort>=5.10.1,<6.0",  # Import sorting linter
+        "black>=22.12.0",  # auto-formatter and linter
+        "mypy>=0.991",  # Static type analyzer
+        "types-setuptools",  # Needed for mypy typeshed
+        "flake8>=5.0.4",  # Style linter
+        "isort>=5.10.1",  # Import sorting linter
     ],
     "doc": [
         "Sphinx>=3.4.3,<4",  # Documentation generator
@@ -65,7 +66,7 @@ setup(
         "eth-account",  # Use same version as eth-ape
         "eth-typing>=3.1",  # Influenced by eth-ape so no upper pin
         "click",  # Use same version as eth-ape
-        "trezor[ethereum]>=0.13.3,<0.14",
+        "trezor[ethereum]>=0.13.5,<0.14",
     ],
     entry_points={
         "ape_cli_subcommands": [

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ extras_require = {
         "black>=22.12.0",  # auto-formatter and linter
         "mypy>=0.991",  # Static type analyzer
         "types-setuptools",  # Needed for mypy typeshed
+        "types-PyYAML",  # Needed for mypy typeshed
         "flake8>=5.0.4",  # Style linter
         "isort>=5.10.1",  # Import sorting linter
     ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,21 @@ def test_add_specify_hd_path(mock_client, runner, cli, accounts, clean, mock_cli
     assert mock_client_factory.call_args[0][-1].path == hd_path
 
 
+def test_add_uses_hd_path_from_config(
+    mock_client, temp_config, runner, cli, clean, mock_client_factory, accounts
+):
+    mock_client.get_account_path.return_value = ZERO_ADDRESS
+    hd_path = "m/1'/60'/0'/0"
+    data = {"trezor": {"hd_path": hd_path}}
+    with temp_config(data):
+        result = runner.invoke(cli, ["add", NEW_ACCOUNT_ALIAS], input="0\n")
+        assert result.exit_code == 0, result.output
+        assert mock_client_factory.call_args[0][0].path == hd_path
+
+    account = accounts.load(NEW_ACCOUNT_ALIAS)
+    assert str(account.hd_path) == "m/1'/60'/0'/0/0"
+
+
 def test_list(runner, cli, existing_key_file):
     result = runner.invoke(cli, ["list"], catch_exceptions=False)
     assert result.exit_code == 0, result.output

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@ import ape
 import pytest
 from ape.logging import LogLevel
 from hexbytes import HexBytes
-from trezorlib.messages import SafetyCheckLevel  # type: ignore
+from trezorlib.messages import SafetyCheckLevel
 
 from ape_trezor.client import TrezorAccountClient, TrezorClient, extract_signature_vrs_bytes
 


### PR DESCRIPTION
### What I did

Allows setting the HD Path in an `ape-config.yaml` file.
This helps users avoid using the default path and having to mess with security settings.
Trezor prefers 3rd party wallets use different HD path than the default.

### How I did it

register a config and update the hd path option handler and add some tests.

### How to verify it

```yaml
trezor:
  hd_path: "m/44'/2'/0'/0"
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
