### PR TITLE
docs: added information about WSL2 USB to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Ape Trezor is a plugin for [Ape Framework](https://github.com/ApeWorx/ape) which
 
 * [python3](https://www.python.org/downloads) version 3.8 or greater, python3-dev
 
+Note: USB does not work in WSL2 environments natively and is [not currently supported](https://github.com/microsoft/WSL/issues/5158). 
+
 ## Installation
 
 ### via `pip`

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
     ],
     "lint": [
         "black>=22.6.0,<23.0",  # auto-formatter and linter
-        "mypy>=0.971,<1.0",  # Static type analyzer
+        "mypy==0.982",  # Static type analyzer
         "flake8>=4.0.1,<5.0",  # Style linter
         "isort>=5.10.1,<6.0",  # Import sorting linter
     ],


### PR DESCRIPTION
fixes: APE-295

### What I did
update documentation to show lack of support for wsl2 because of usb driver issues which WSL2 does not plan to fix
### How I did it
updated documentation
### How to verify it
review documentation

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
