### PR TITLE
fix: ensure can install [APE-952]

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -16,7 +16,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: pip install commitizen

--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -17,7 +17,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: pip install commitizen

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: |
@@ -47,7 +47,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: |
@@ -94,7 +94,7 @@ jobs:
 #        - name: Setup Python
 #          uses: actions/setup-python@v4
 #          with:
-#              python-version: 3.8
+#              python-version: "3.10"
 #
 #        - name: Install Dependencies
 #          run: pip install .[test]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
       - id: black
         name: black

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,4 +46,4 @@ A pull request represents the start of a discussion, and doesn't necessarily nee
 If you are opening a work-in-progress pull request to verify that it passes CI tests, please consider
 [marking it as a draft](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
 
-Join the Ethereum Python [Discord](https://discord.gg/PcEJ54yX) if you have any questions.
+Join the ApeWorX [Discord](https://discord.gg/apeworx) if you have any questions.

--- a/ape_trezor/_cli.py
+++ b/ape_trezor/_cli.py
@@ -123,7 +123,6 @@ def delete_all(cli_ctx, skip_confirmation):
 @click.argument("message")
 @ape_cli_context()
 def sign_message(cli_ctx, alias, message):
-
     if alias not in accounts.aliases:
         cli_ctx.abort(f"Account with alias '{alias}' does not exist.")
 
@@ -145,7 +144,6 @@ def sign_message(cli_ctx, alias, message):
 @click.argument("message")
 @click.argument("signature")
 def verify_message(message, signature):
-
     eip191message = encode_defunct(text=message)
 
     try:

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     url="https://github.com/ApeWorX/ape-trezor",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.8,<0.7",
+        "eth-ape>=0.6.9,<0.7",
         "eth-account",  # Use same version as eth-ape
         "eth-typing>=3.1",  # Influenced by eth-ape so no upper pin
         "click",  # Use same version as eth-ape

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require = {
         "eip712",  # Used for cleaner test cases
     ],
     "lint": [
-        "black>=22.12.0",  # auto-formatter and linter
+        "black>=23.3.0",  # auto-formatter and linter
         "mypy>=0.991",  # Static type analyzer
         "types-setuptools",  # Needed for mypy typeshed
         "types-PyYAML",  # Needed for mypy typeshed
@@ -66,11 +66,11 @@ setup(
     url="https://github.com/ApeWorX/ape-trezor",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.0,<0.7",
+        "eth-ape>=0.6.8,<0.7",
         "eth-account",  # Use same version as eth-ape
         "eth-typing>=3.1",  # Influenced by eth-ape so no upper pin
         "click",  # Use same version as eth-ape
-        "trezor[ethereum]>=0.13.5,<0.14",
+        "trezor[ethereum]>=0.13.6,<0.14",
     ],
     entry_points={
         "ape_cli_subcommands": [


### PR DESCRIPTION
### What I did

the real fix was releasing evm-trace but this ensure the plugin works
it did require releasing eth-ape as well though so we have to bump that

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
